### PR TITLE
OrderFragment 리팩토링: MVVM + Flow 전환, DiffUtil/ListAdapter 적용, Dispatcher 주입, 테스트 보강

### DIFF
--- a/.idea/deploymentTargetSelector.xml
+++ b/.idea/deploymentTargetSelector.xml
@@ -13,6 +13,9 @@
         </DropdownSelection>
         <DialogSelection />
       </SelectionState>
+      <SelectionState runConfigName="MainActivity">
+        <option name="selectionMode" value="DROPDOWN" />
+      </SelectionState>
     </selectionStates>
   </component>
 </project>

--- a/app/src/main/java/eloom/holybean/network/NetworkModule.kt
+++ b/app/src/main/java/eloom/holybean/network/NetworkModule.kt
@@ -3,8 +3,10 @@ package eloom.holybean.network
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
-import javax.inject.Singleton
 import dagger.hilt.components.SingletonComponent
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import javax.inject.Singleton
 
 @Module
 @InstallIn(SingletonComponent::class)
@@ -14,4 +16,8 @@ object NetworkModule {
     @Singleton
     fun provideApiService(): ApiService =
         RetrofitClient.retrofit.create(ApiService::class.java)
+
+    @Provides
+    @Singleton
+    fun provideCoroutineDispatcher(): CoroutineDispatcher = Dispatchers.Main
 }

--- a/app/src/main/java/eloom/holybean/ui/credits/CreditsFragment.kt
+++ b/app/src/main/java/eloom/holybean/ui/credits/CreditsFragment.kt
@@ -49,6 +49,7 @@ class CreditsFragment : Fragment(), CreditsFragmentFunction {
     private lateinit var creditsList: ArrayList<CreditItem>
     private lateinit var basket: RecyclerView
     private var basketList = arrayListOf<OrdersDetailItem>()
+    private lateinit var ordersDetailAdapter: OrdersDetailAdapter
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle? ): View? {
         binding = FragmentCreditBinding.inflate(inflater, container, false)
@@ -99,7 +100,7 @@ class CreditsFragment : Fragment(), CreditsFragmentFunction {
                 }
                 basketList.clear()
                 basketList.addAll(newItems)
-                basket.adapter?.notifyDataSetChanged()
+                ordersDetailAdapter.submitList(basketList.toList())
             }
         }
     }
@@ -119,7 +120,7 @@ class CreditsFragment : Fragment(), CreditsFragmentFunction {
 
     private fun initBasket(){
         basket = binding.basket
-        val ordersDetailAdapter = OrdersDetailAdapter(basketList)
+        ordersDetailAdapter = OrdersDetailAdapter()
         basket.apply{
             adapter = ordersDetailAdapter
             layoutManager = GridLayoutManager(context, 1)
@@ -133,7 +134,7 @@ class CreditsFragment : Fragment(), CreditsFragmentFunction {
         orderNum.text = num.toString()
         totalPrice.text = total.toString()
         basketList.clear()
-        basket.adapter?.notifyDataSetChanged()
+        ordersDetailAdapter.submitList(emptyList())
     }
 
     private fun observeViewModel() {

--- a/app/src/main/java/eloom/holybean/ui/orderlist/OrdersAdapter.kt
+++ b/app/src/main/java/eloom/holybean/ui/orderlist/OrdersAdapter.kt
@@ -4,12 +4,15 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.TextView
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
 import eloom.holybean.R
-import eloom.holybean.interfaces.OrdersFragmentFunction
 import eloom.holybean.data.model.OrderItem
 
-class OrdersAdapter(private var ordersList: ArrayList<OrderItem>, private val ordersListener: OrdersFragmentFunction) : RecyclerView.Adapter<OrdersAdapter.OrdersHolder>() {
+class OrdersAdapter(
+    private val onOrderClick: (orderNumber: Int, totalAmount: Int) -> Unit
+) : ListAdapter<OrderItem, OrdersAdapter.OrdersHolder>(OrderItemDiffCallback()) {
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): OrdersHolder {
         val view = LayoutInflater.from(parent.context).inflate(R.layout.list_item_orders, parent, false)
@@ -17,30 +20,35 @@ class OrdersAdapter(private var ordersList: ArrayList<OrderItem>, private val or
     }
 
     override fun onBindViewHolder(holder: OrdersHolder, position: Int) {
-        val item = ordersList[position]
-        holder.ordersId.text = "주문번호: ${item.orderId}"
-        holder.ordersAmount.text = "주문금액: ${item.totalAmount}"
-        holder.ordersMethod.text = "주문방식: ${item.method}"
-        holder.ordersOrderer.text = "주문자: ${item.orderer}"
-        holder.itemView.setOnClickListener {
-            ordersListener.newOrderSelected(item.orderId, item.totalAmount)
+        val item = getItem(position)
+        holder.bind(item, onOrderClick)
+    }
+
+    class OrdersHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {
+        private val ordersId: TextView = itemView.findViewById(R.id.orders_id)
+        private val ordersAmount: TextView = itemView.findViewById(R.id.orders_amount)
+        private val ordersMethod: TextView = itemView.findViewById(R.id.orders_method)
+        private val ordersOrderer: TextView = itemView.findViewById(R.id.orders_orderer)
+
+        fun bind(item: OrderItem, onOrderClick: (Int, Int) -> Unit) {
+            ordersId.text = "주문번호: ${item.orderId}"
+            ordersAmount.text = "주문금액: ${item.totalAmount}"
+            ordersMethod.text = "주문방식: ${item.method}"
+            ordersOrderer.text = "주문자: ${item.orderer}"
+            
+            itemView.setOnClickListener {
+                onOrderClick(item.orderId, item.totalAmount)
+            }
         }
     }
 
-    override fun getItemCount(): Int {
-        return ordersList.size
-    }
+    private class OrderItemDiffCallback : DiffUtil.ItemCallback<OrderItem>() {
+        override fun areItemsTheSame(oldItem: OrderItem, newItem: OrderItem): Boolean {
+            return oldItem.orderId == newItem.orderId
+        }
 
-    inner class OrdersHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {
-        val ordersId: TextView = itemView.findViewById(R.id.orders_id)
-        val ordersAmount: TextView = itemView.findViewById(R.id.orders_amount)
-        val ordersMethod: TextView = itemView.findViewById(R.id.orders_method)
-        val ordersOrderer: TextView = itemView.findViewById(R.id.orders_orderer)
-    }
-
-    fun updateData(newOrders: List<OrderItem>) {
-        ordersList.clear() // 기존 데이터 초기화
-        ordersList.addAll(newOrders) // 새로운 데이터 추가
-        notifyDataSetChanged() // RecyclerView 갱신
+        override fun areContentsTheSame(oldItem: OrderItem, newItem: OrderItem): Boolean {
+            return oldItem == newItem
+        }
     }
 }

--- a/app/src/main/java/eloom/holybean/ui/orderlist/OrdersDetailAdapter.kt
+++ b/app/src/main/java/eloom/holybean/ui/orderlist/OrdersDetailAdapter.kt
@@ -4,12 +4,13 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.TextView
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
 import eloom.holybean.R
 import eloom.holybean.data.model.OrdersDetailItem
 
-class OrdersDetailAdapter(private var basketList: ArrayList<OrdersDetailItem>) :
-    RecyclerView.Adapter<OrdersDetailAdapter.OrdersDetailHolder>() {
+class OrdersDetailAdapter : ListAdapter<OrdersDetailItem, OrdersDetailAdapter.OrdersDetailHolder>(OrdersDetailDiffCallback()) {
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): OrdersDetailHolder {
         val view = LayoutInflater.from(parent.context).inflate(R.layout.list_item_basket, parent, false)
@@ -17,26 +18,29 @@ class OrdersDetailAdapter(private var basketList: ArrayList<OrdersDetailItem>) :
     }
 
     override fun onBindViewHolder(holder: OrdersDetailHolder, position: Int) {
-        val item = basketList[position]
-        holder.basketName.text = item.name
-        holder.basketCount.text = item.count.toString()
-        holder.basketTotal.text = item.subtotal.toString()
+        val item = getItem(position)
+        holder.bind(item)
     }
 
-    override fun getItemCount(): Int {
-        return basketList.size
+    class OrdersDetailHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {
+        private val basketName: TextView = itemView.findViewById(R.id.basket_name)
+        private val basketCount: TextView = itemView.findViewById(R.id.basket_count)
+        private val basketTotal: TextView = itemView.findViewById(R.id.basket_price)
+
+        fun bind(item: OrdersDetailItem) {
+            basketName.text = item.name
+            basketCount.text = item.count.toString()
+            basketTotal.text = item.subtotal.toString()
+        }
     }
 
-    // 데이터 갱신 메서드 추가
-    fun updateData(newBasketList: List<OrdersDetailItem>) {
-        basketList.clear()
-        basketList.addAll(newBasketList)
-        notifyDataSetChanged() // UI 갱신
-    }
+    private class OrdersDetailDiffCallback : DiffUtil.ItemCallback<OrdersDetailItem>() {
+        override fun areItemsTheSame(oldItem: OrdersDetailItem, newItem: OrdersDetailItem): Boolean {
+            return oldItem.name == newItem.name && oldItem.count == newItem.count && oldItem.subtotal == newItem.subtotal
+        }
 
-    inner class OrdersDetailHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {
-        val basketName: TextView = itemView.findViewById(R.id.basket_name)
-        val basketCount: TextView = itemView.findViewById(R.id.basket_count)
-        val basketTotal: TextView = itemView.findViewById(R.id.basket_price)
+        override fun areContentsTheSame(oldItem: OrdersDetailItem, newItem: OrdersDetailItem): Boolean {
+            return oldItem == newItem
+        }
     }
 }

--- a/app/src/main/java/eloom/holybean/ui/orderlist/OrdersFragment.kt
+++ b/app/src/main/java/eloom/holybean/ui/orderlist/OrdersFragment.kt
@@ -93,6 +93,12 @@ class OrdersFragment : Fragment(), OrdersFragmentFunction {
         lifecycleScope.launch {
             ordersList = lambdaRepository.getOrdersOfDay()
             boardAdapter.updateData(ordersList)
+            
+            if (ordersList.isNotEmpty()) {
+                val firstOrder = ordersList.first()
+                newOrderSelected(firstOrder.orderId, firstOrder.totalAmount)
+                viewModel.fetchOrderDetail(firstOrder.orderId)
+            }
         }
     }
 
@@ -115,6 +121,10 @@ class OrdersFragment : Fragment(), OrdersFragmentFunction {
 
         viewModel.orderDetails.observe(viewLifecycleOwner) { fetchedBasketList ->
             ordersDetailAdapter.updateData(fetchedBasketList)
+        }
+        
+        viewModel.error.observe(viewLifecycleOwner) { errorMessage ->
+            showToastMessage(errorMessage)
         }
     }
 
@@ -186,5 +196,6 @@ class OrdersFragment : Fragment(), OrdersFragmentFunction {
         totalPrice.text = total.toString()
         basketList.clear()
         basket.adapter?.notifyDataSetChanged()
+        viewModel.fetchOrderDetail(num)
     }
 }

--- a/app/src/main/java/eloom/holybean/ui/orderlist/OrdersViewModel.kt
+++ b/app/src/main/java/eloom/holybean/ui/orderlist/OrdersViewModel.kt
@@ -63,9 +63,13 @@ class OrdersViewModel @Inject constructor(
         viewModelScope.launch {
             try {
                 val fetchedBasketList = lambdaRepository.getOrderDetail(getCurrentDate(), orderNumber)
-                _orderDetails.postValue(fetchedBasketList)
+                if (fetchedBasketList.isEmpty()) {
+                    _error.postValue("주문 내역이 없습니다.")
+                } else {
+                    _orderDetails.postValue(fetchedBasketList)
+                }
             } catch (e: Exception) {
-                _error.postValue("Failed to fetch order details: ${e.message}")
+                _error.postValue("주문 조회 중 오류가 발생했습니다: ${e.message}")
             }
         }
     }

--- a/app/src/main/java/eloom/holybean/ui/orderlist/OrdersViewModel.kt
+++ b/app/src/main/java/eloom/holybean/ui/orderlist/OrdersViewModel.kt
@@ -1,35 +1,51 @@
 package eloom.holybean.ui.orderlist
 
-import androidx.lifecycle.LiveData
-import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
+import eloom.holybean.data.model.OrderItem
 import eloom.holybean.data.model.OrdersDetailItem
 import eloom.holybean.data.repository.LambdaRepository
 import eloom.holybean.printer.OrdersPrinter
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.*
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.channels.BufferOverflow
 import java.text.SimpleDateFormat
 import java.util.*
 import javax.inject.Inject
 
 @HiltViewModel
 class OrdersViewModel @Inject constructor(
-    private val lambdaRepository: LambdaRepository
+    private val lambdaRepository: LambdaRepository,
+    private val dispatcher: CoroutineDispatcher
 ) : ViewModel() {
 
-    private val _orderDetails = MutableLiveData<List<OrdersDetailItem>>()
-    val orderDetails: LiveData<List<OrdersDetailItem>> get() = _orderDetails
+    private val _uiState = MutableStateFlow(OrdersUiState())
+    val uiState: StateFlow<OrdersUiState> = _uiState.asStateFlow()
 
-    private val _error = MutableLiveData<String>()
-    val error: LiveData<String> get() = _error
+    private val _uiEvent = MutableSharedFlow<OrdersUiEvent>(
+        replay = 1,
+        extraBufferCapacity = 16,
+        onBufferOverflow = BufferOverflow.DROP_OLDEST
+    )
+    val uiEvent: SharedFlow<OrdersUiEvent> = _uiEvent.asSharedFlow()
 
-    private val _deleteStatus = MutableLiveData<DeleteStatus>()
-    val deleteStatus: LiveData<DeleteStatus> get() = _deleteStatus
+    data class OrdersUiState(
+        val ordersList: List<OrderItem> = emptyList(),
+        val selectedOrderNumber: Int = 0,
+        val selectedOrderTotal: Int = 0,
+        val orderDetails: List<OrdersDetailItem> = emptyList(),
+        val isLoading: Boolean = false,
+        val deleteStatus: DeleteStatus = DeleteStatus.Idle
+    )
 
-    private val _deleteResult = MutableLiveData<Boolean?>()
-    val deleteResult: LiveData<Boolean?> get() = _deleteResult
+    sealed class OrdersUiEvent {
+        data class ShowToast(val message: String) : OrdersUiEvent()
+        object RefreshOrders : OrdersUiEvent()
+    }
 
     sealed class DeleteStatus {
         object Idle : DeleteStatus()
@@ -38,21 +54,68 @@ class OrdersViewModel @Inject constructor(
         data class Error(val message: String) : DeleteStatus()
     }
 
+    init {
+        loadOrdersOfDay()
+    }
+
     fun getCurrentDate(): String {
-        val dateFormat = SimpleDateFormat("yyyy-MM-dd")
+        val dateFormat = SimpleDateFormat("yyyy-MM-dd", Locale.getDefault())
         val currentDate = Date()
         return dateFormat.format(currentDate)
     }
 
-    fun reprint(orderNum: Int, basketList: ArrayList<OrdersDetailItem>) {
+    fun loadOrdersOfDay() {
+        viewModelScope.launch(dispatcher) {
+            try {
+                _uiState.update { it.copy(isLoading = true) }
+                val ordersList = lambdaRepository.getOrdersOfDay()
+                _uiState.update { 
+                    it.copy(
+                        ordersList = ordersList,
+                        isLoading = false
+                    )
+                }
+                
+                // Auto-select first order if available
+                if (ordersList.isNotEmpty()) {
+                    val firstOrder = ordersList.first()
+                    selectOrder(firstOrder.orderId, firstOrder.totalAmount)
+                }
+            } catch (e: Exception) {
+                _uiState.update { it.copy(isLoading = false) }
+                _uiEvent.tryEmit(OrdersUiEvent.ShowToast("주문 목록을 불러오는 중 오류가 발생했습니다: ${e.message}"))
+            }
+        }
+    }
+
+    fun selectOrder(orderNumber: Int, totalAmount: Int) {
+        _uiState.update { 
+            it.copy(
+                selectedOrderNumber = orderNumber,
+                selectedOrderTotal = totalAmount,
+                orderDetails = emptyList() // Clear previous details
+            )
+        }
+        fetchOrderDetail(orderNumber)
+    }
+
+    fun reprint() {
+        val currentState = _uiState.value
+        if (currentState.orderDetails.isEmpty()) {
+            viewModelScope.launch(dispatcher) {
+                _uiEvent.tryEmit(OrdersUiEvent.ShowToast("주문 조회 후 클릭해주세요"))
+            }
+            return
+        }
+
         val printer = OrdersPrinter()
-        val text = printer.makeText(orderNum, basketList)
-        viewModelScope.launch {
+        val orderDetailsArrayList = ArrayList(currentState.orderDetails)
+        val text = printer.makeText(currentState.selectedOrderNumber, orderDetailsArrayList)
+        viewModelScope.launch(dispatcher) {
             try {
                 printer.print(text)
-                delay(2000)
             } catch (e: Exception) {
-                _error.postValue("Printer error: ${e.message}")
+                _uiEvent.tryEmit(OrdersUiEvent.ShowToast("Printer error: ${e.message}"))
             } finally {
                 printer.disconnect()
             }
@@ -60,43 +123,49 @@ class OrdersViewModel @Inject constructor(
     }
 
     fun fetchOrderDetail(orderNumber: Int) {
-        viewModelScope.launch {
+        viewModelScope.launch(dispatcher) {
             try {
                 val fetchedBasketList = lambdaRepository.getOrderDetail(getCurrentDate(), orderNumber)
                 if (fetchedBasketList.isEmpty()) {
-                    _error.postValue("주문 내역이 없습니다.")
+                    _uiEvent.tryEmit(OrdersUiEvent.ShowToast("주문 내역이 없습니다."))
                 } else {
-                    _orderDetails.postValue(fetchedBasketList)
+                    _uiState.update { it.copy(orderDetails = fetchedBasketList) }
                 }
             } catch (e: Exception) {
-                _error.postValue("주문 조회 중 오류가 발생했습니다: ${e.message}")
+                _uiEvent.tryEmit(OrdersUiEvent.ShowToast("주문 조회 중 오류가 발생했습니다: ${e.message}"))
             }
         }
     }
 
-    fun deleteOrder(orderNumber: Int) {
-        viewModelScope.launch {
+    fun deleteOrder() {
+        val currentState = _uiState.value
+        if (currentState.orderDetails.isEmpty()) {
+            viewModelScope.launch(dispatcher) {
+                _uiEvent.tryEmit(OrdersUiEvent.ShowToast("주문 조회 후 클릭해주세요"))
+            }
+            return
+        }
+
+        viewModelScope.launch(dispatcher) {
             try {
-                _deleteStatus.postValue(DeleteStatus.Loading)
-                val result = lambdaRepository.deleteOrder(getCurrentDate(), orderNumber)
+                _uiState.update { it.copy(deleteStatus = DeleteStatus.Loading) }
+                val result = lambdaRepository.deleteOrder(getCurrentDate(), currentState.selectedOrderNumber)
                 
-                if (result == true) {
-                    _deleteStatus.postValue(DeleteStatus.Success)
-                    _deleteResult.postValue(true)
+                if (result) {
+                    _uiState.update { it.copy(deleteStatus = DeleteStatus.Success) }
+                    _uiEvent.tryEmit(OrdersUiEvent.ShowToast("주문이 성공적으로 삭제되었습니다."))
+                    _uiEvent.tryEmit(OrdersUiEvent.RefreshOrders)
                 } else {
-                    _deleteStatus.postValue(DeleteStatus.Error("주문 삭제에 실패했습니다."))
-                    _deleteResult.postValue(false)
+                    _uiState.update { it.copy(deleteStatus = DeleteStatus.Error("주문 삭제에 실패했습니다.")) }
                 }
             } catch (e: Exception) {
                 e.printStackTrace()
-                _deleteStatus.postValue(DeleteStatus.Error("오류가 발생했습니다. 다시 시도해주세요."))
-                _deleteResult.postValue(false)
+                _uiState.update { it.copy(deleteStatus = DeleteStatus.Error("오류가 발생했습니다. 다시 시도해주세요.")) }
             }
         }
     }
 
     fun resetDeleteStatus() {
-        _deleteStatus.postValue(DeleteStatus.Idle)
-        _deleteResult.postValue(null)
+        _uiState.update { it.copy(deleteStatus = DeleteStatus.Idle) }
     }
 }

--- a/app/src/test/kotlin/eloom/holybean/ui/orderlist/OrdersViewModelTest.kt
+++ b/app/src/test/kotlin/eloom/holybean/ui/orderlist/OrdersViewModelTest.kt
@@ -2,16 +2,20 @@ package eloom.holybean.ui.orderlist
 
 import android.bluetooth.BluetoothAdapter
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
-import androidx.lifecycle.Observer
+import eloom.holybean.data.model.OrderItem
 import eloom.holybean.data.model.OrdersDetailItem
 import eloom.holybean.data.repository.LambdaRepository
 import eloom.holybean.printer.OrdersPrinter
 import io.mockk.*
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.*
 import org.junit.After
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -31,7 +35,9 @@ class OrdersViewModelTest {
     @Before
     fun setUp() {
         Dispatchers.setMain(testDispatcher)
-        viewModel = OrdersViewModel(lambdaRepository)
+        // Mock the initial loadOrdersOfDay call to prevent automatic execution
+        coEvery { lambdaRepository.getOrdersOfDay() } returns arrayListOf()
+        viewModel = OrdersViewModel(lambdaRepository, testDispatcher)
     }
 
     @After
@@ -54,15 +60,61 @@ class OrdersViewModelTest {
     }
 
     @Test
-    fun `fetchOrderDetail should update orderDetails LiveData on success`() = runTest {
+    fun `loadOrdersOfDay should update uiState with orders list on success`() = runTest {
+        // Given
+        val testViewModel = OrdersViewModel(lambdaRepository, testDispatcher)
+        val mockOrders = arrayListOf(
+            OrderItem(orderId = 1, totalAmount = 8000, method = "Card", orderer = "John"),
+            OrderItem(orderId = 2, totalAmount = 4500, method = "Cash", orderer = "Jane")
+        )
+        val mockOrderDetails = arrayListOf(
+            OrdersDetailItem(name = "Americano", count = 2, subtotal = 8000)
+        )
+        
+        coEvery { lambdaRepository.getOrdersOfDay() } returns mockOrders
+        coEvery { lambdaRepository.getOrderDetail(any(), any()) } returns mockOrderDetails
+
+        // When
+        testViewModel.loadOrdersOfDay()
+
+        // Then
+        val uiState = testViewModel.uiState.first()
+        assertEquals(mockOrders, uiState.ordersList)
+        assertEquals(1, uiState.selectedOrderNumber)
+        assertEquals(8000, uiState.selectedOrderTotal)
+        assertEquals(mockOrderDetails, uiState.orderDetails)
+        assertEquals(false, uiState.isLoading)
+    }
+
+    @Test
+    fun `selectOrder should update uiState with selected order info`() = runTest {
+        // Given
+        val orderNumber = 123
+        val totalAmount = 5000
+        val mockOrderDetails = arrayListOf(
+            OrdersDetailItem(name = "Latte", count = 1, subtotal = 4500)
+        )
+        
+        coEvery { lambdaRepository.getOrderDetail(any(), any()) } returns mockOrderDetails
+
+        // When
+        viewModel.selectOrder(orderNumber, totalAmount)
+
+        // Then
+        val uiState = viewModel.uiState.first()
+        assertEquals(orderNumber, uiState.selectedOrderNumber)
+        assertEquals(totalAmount, uiState.selectedOrderTotal)
+        assertEquals(mockOrderDetails, uiState.orderDetails)
+    }
+
+    @Test
+    fun `fetchOrderDetail should update uiState on success`() = runTest {
         // Given
         val orderNumber = 123
         val mockOrderDetails = arrayListOf(
             OrdersDetailItem(name = "Americano", count = 2, subtotal = 8000),
             OrdersDetailItem(name = "Latte", count = 1, subtotal = 4500)
         )
-        val observer = mockk<Observer<List<OrdersDetailItem>>>(relaxed = true)
-        viewModel.orderDetails.observeForever(observer)
 
         val currentDate = viewModel.getCurrentDate()
         coEvery { lambdaRepository.getOrderDetail(currentDate, orderNumber) } returns mockOrderDetails
@@ -72,56 +124,81 @@ class OrdersViewModelTest {
 
         // Then
         coVerify { lambdaRepository.getOrderDetail(currentDate, orderNumber) }
-        verify { observer.onChanged(mockOrderDetails) }
-        viewModel.orderDetails.removeObserver(observer)
+        val uiState = viewModel.uiState.first()
+        assertEquals(mockOrderDetails, uiState.orderDetails)
     }
 
     @Test
-    fun `fetchOrderDetail should post error message when order list is empty`() = runTest {
+    fun `fetchOrderDetail should emit toast event when order list is empty`() = runTest {
         // Given
+        val testViewModel = OrdersViewModel(lambdaRepository, testDispatcher)
         val orderNumber = 123
-        val emptyOrderDetails = arrayListOf<OrdersDetailItem>()
-        val errorObserver = mockk<Observer<String>>(relaxed = true)
-        viewModel.error.observeForever(errorObserver)
 
-        val currentDate = viewModel.getCurrentDate()
-        coEvery { lambdaRepository.getOrderDetail(currentDate, orderNumber) } returns emptyOrderDetails
+        val currentDate = testViewModel.getCurrentDate()
+        coEvery { lambdaRepository.getOrderDetail(currentDate, orderNumber) } returns arrayListOf()
+
+        // Collect events before triggering the action
+        val events = mutableListOf<OrdersViewModel.OrdersUiEvent>()
+        val collectJob = launch {
+            testViewModel.uiEvent.collect { events.add(it) }
+        }
 
         // When
-        viewModel.fetchOrderDetail(orderNumber)
+        testViewModel.fetchOrderDetail(orderNumber)
+        
+        // Wait for the coroutine to complete
+        advanceUntilIdle()
 
         // Then
         coVerify { lambdaRepository.getOrderDetail(currentDate, orderNumber) }
-        verify { errorObserver.onChanged("주문 내역이 없습니다.") }
-        viewModel.error.removeObserver(errorObserver)
+        assertEquals(1, events.size)
+        assertTrue(events.first() is OrdersViewModel.OrdersUiEvent.ShowToast)
+        assertEquals("주문 내역이 없습니다.", (events.first() as OrdersViewModel.OrdersUiEvent.ShowToast).message)
+        
+        collectJob.cancel()
     }
 
     @Test
-    fun `fetchOrderDetail should post error message on repository failure`() = runTest {
+    fun `fetchOrderDetail should emit error event on repository failure`() = runTest {
         // Given
+        val testViewModel = OrdersViewModel(lambdaRepository, testDispatcher)
         val orderNumber = 456
         val errorMessage = "Network error"
         val exception = RuntimeException(errorMessage)
-        val errorObserver = mockk<Observer<String>>(relaxed = true)
-        viewModel.error.observeForever(errorObserver)
 
         coEvery { lambdaRepository.getOrderDetail(any(), any()) } throws exception
 
+        // Collect events before triggering the action
+        val events = mutableListOf<OrdersViewModel.OrdersUiEvent>()
+        val collectJob = launch {
+            testViewModel.uiEvent.collect { events.add(it) }
+        }
+
         // When
-        viewModel.fetchOrderDetail(orderNumber)
+        testViewModel.fetchOrderDetail(orderNumber)
+        
+        // Wait for the coroutine to complete
+        advanceUntilIdle()
 
         // Then
+        assertEquals(1, events.size)
+        assertTrue(events.first() is OrdersViewModel.OrdersUiEvent.ShowToast)
         val expectedErrorMessage = "주문 조회 중 오류가 발생했습니다: $errorMessage"
-        verify { errorObserver.onChanged(expectedErrorMessage) }
-        viewModel.error.removeObserver(errorObserver)
+        assertEquals(expectedErrorMessage, (events.first() as OrdersViewModel.OrdersUiEvent.ShowToast).message)
+        
+        collectJob.cancel()
     }
 
     @Test
-    fun `reprint should call printer methods correctly`() = runTest {
+    fun `reprint should call printer methods correctly when order details exist`() = runTest {
         // Given
-        val orderNum = 101
-        val basketList = arrayListOf(OrdersDetailItem("Coffee", 1, 1000))
+        val orderDetails = arrayListOf(OrdersDetailItem("Coffee", 1, 1000))
         val testText = "Test Print Text"
+
+        // Set up the UI state with order details
+        viewModel.selectOrder(101, 1000)
+        coEvery { lambdaRepository.getOrderDetail(any(), any()) } returns orderDetails
+        viewModel.fetchOrderDetail(101)
 
         mockkStatic(BluetoothAdapter::class)
         every { BluetoothAdapter.getDefaultAdapter() } returns null
@@ -131,25 +208,53 @@ class OrdersViewModelTest {
         coEvery { anyConstructed<OrdersPrinter>().disconnect() } just runs
 
         // When
-        viewModel.reprint(orderNum, basketList)
+        viewModel.reprint()
         advanceUntilIdle()
 
         // Then
-        verify { anyConstructed<OrdersPrinter>().makeText(orderNum, basketList) }
+        verify { anyConstructed<OrdersPrinter>().makeText(101, orderDetails) }
         coVerify { anyConstructed<OrdersPrinter>().print(testText) }
         coVerify { anyConstructed<OrdersPrinter>().disconnect() }
     }
 
     @Test
-    fun `reprint should post error and disconnect when printing fails`() = runTest {
+    fun `reprint should emit toast event when no order details exist`() = runTest {
+        // Given - UI state has no order details (default empty state)
+        val testViewModel = OrdersViewModel(lambdaRepository, testDispatcher)
+
+        // Collect events before triggering the action
+        val events = mutableListOf<OrdersViewModel.OrdersUiEvent>()
+        val collectJob = launch {
+            testViewModel.uiEvent.collect { events.add(it) }
+        }
+
+        // When
+        testViewModel.reprint()
+        
+        // Wait for the coroutine to complete
+        advanceUntilIdle()
+
+        // Then
+        assertEquals(1, events.size)
+        assertTrue(events.first() is OrdersViewModel.OrdersUiEvent.ShowToast)
+        assertEquals("주문 조회 후 클릭해주세요", (events.first() as OrdersViewModel.OrdersUiEvent.ShowToast).message)
+        
+        collectJob.cancel()
+    }
+
+    @Test
+    fun `reprint should emit error event and disconnect when printing fails`() = runTest {
         // Given
-        val orderNum = 102
-        val basketList = arrayListOf(OrdersDetailItem("Tea", 1, 1500))
+        val testViewModel = OrdersViewModel(lambdaRepository, testDispatcher)
+        val orderDetails = arrayListOf(OrdersDetailItem("Tea", 1, 1500))
         val testText = "Test Print Text"
         val errorMessage = "Printer connection failed"
         val printException = Exception(errorMessage)
-        val errorObserver = mockk<Observer<String>>(relaxed = true)
-        viewModel.error.observeForever(errorObserver)
+
+        // Set up the UI state with order details
+        testViewModel.selectOrder(102, 1500)
+        coEvery { lambdaRepository.getOrderDetail(any(), any()) } returns orderDetails
+        testViewModel.fetchOrderDetail(102)
 
         mockkStatic(BluetoothAdapter::class)
         every { BluetoothAdapter.getDefaultAdapter() } returns null
@@ -158,112 +263,133 @@ class OrdersViewModelTest {
         coEvery { anyConstructed<OrdersPrinter>().print(any()) } throws printException
         coEvery { anyConstructed<OrdersPrinter>().disconnect() } just runs
 
+        // Collect events before triggering the action
+        val events = mutableListOf<OrdersViewModel.OrdersUiEvent>()
+        val collectJob = launch {
+            testViewModel.uiEvent.collect { events.add(it) }
+        }
+
         // When
-        viewModel.reprint(orderNum, basketList)
+        testViewModel.reprint()
         advanceUntilIdle()
 
         // Then
+        // Find the printer error event (might be multiple events from fetchOrderDetail first)
+        val printerErrorEvent = events.find { 
+            it is OrdersViewModel.OrdersUiEvent.ShowToast && 
+            it.message.contains("Printer error")
+        }
+        assertNotNull(printerErrorEvent)
         val expectedErrorMessage = "Printer error: $errorMessage"
-        verify { errorObserver.onChanged(expectedErrorMessage) }
+        assertEquals(expectedErrorMessage, (printerErrorEvent as OrdersViewModel.OrdersUiEvent.ShowToast).message)
         coVerify { anyConstructed<OrdersPrinter>().disconnect() }
-        viewModel.error.removeObserver(errorObserver)
+        
+        collectJob.cancel()
+    }
+
+    @Test
+    fun `deleteOrder should emit toast event when no order details exist`() = runTest {
+        // Given - UI state has no order details (default empty state)
+        val testViewModel = OrdersViewModel(lambdaRepository, testDispatcher)
+
+        // Collect events before triggering the action
+        val events = mutableListOf<OrdersViewModel.OrdersUiEvent>()
+        val collectJob = launch {
+            testViewModel.uiEvent.collect { events.add(it) }
+        }
+
+        // When
+        testViewModel.deleteOrder()
+        
+        // Wait for the coroutine to complete
+        advanceUntilIdle()
+
+        // Then
+        assertEquals(1, events.size)
+        assertTrue(events.first() is OrdersViewModel.OrdersUiEvent.ShowToast)
+        assertEquals("주문 조회 후 클릭해주세요", (events.first() as OrdersViewModel.OrdersUiEvent.ShowToast).message)
+        
+        collectJob.cancel()
     }
 
     @Test
     fun `deleteOrder should update deleteStatus to Loading then Success when deletion succeeds`() = runTest {
         // Given
+        val orderDetails = arrayListOf(OrdersDetailItem("Coffee", 1, 1000))
         val orderNumber = 123
         val currentDate = viewModel.getCurrentDate()
-        val deleteStatusObserver = mockk<Observer<OrdersViewModel.DeleteStatus>>(relaxed = true)
-        val deleteResultObserver = mockk<Observer<Boolean?>>(relaxed = true)
         
-        viewModel.deleteStatus.observeForever(deleteStatusObserver)
-        viewModel.deleteResult.observeForever(deleteResultObserver)
+        // Set up the UI state with order details
+        viewModel.selectOrder(orderNumber, 1000)
+        coEvery { lambdaRepository.getOrderDetail(any(), any()) } returns orderDetails
+        viewModel.fetchOrderDetail(orderNumber)
         
         coEvery { lambdaRepository.deleteOrder(currentDate, orderNumber) } returns true
 
         // When
-        viewModel.deleteOrder(orderNumber)
+        viewModel.deleteOrder()
 
         // Then
         coVerify { lambdaRepository.deleteOrder(currentDate, orderNumber) }
-        verify { deleteStatusObserver.onChanged(OrdersViewModel.DeleteStatus.Loading) }
-        verify { deleteStatusObserver.onChanged(OrdersViewModel.DeleteStatus.Success) }
-        verify { deleteResultObserver.onChanged(true) }
-        
-        viewModel.deleteStatus.removeObserver(deleteStatusObserver)
-        viewModel.deleteResult.removeObserver(deleteResultObserver)
+        val finalState = viewModel.uiState.first()
+        assertTrue(finalState.deleteStatus is OrdersViewModel.DeleteStatus.Success)
     }
 
     @Test
     fun `deleteOrder should update deleteStatus to Loading then Error when deletion fails`() = runTest {
         // Given
+        val orderDetails = arrayListOf(OrdersDetailItem("Coffee", 1, 1000))
         val orderNumber = 456
         val currentDate = viewModel.getCurrentDate()
-        val deleteStatusObserver = mockk<Observer<OrdersViewModel.DeleteStatus>>(relaxed = true)
-        val deleteResultObserver = mockk<Observer<Boolean?>>(relaxed = true)
         
-        viewModel.deleteStatus.observeForever(deleteStatusObserver)
-        viewModel.deleteResult.observeForever(deleteResultObserver)
+        // Set up the UI state with order details
+        viewModel.selectOrder(orderNumber, 1000)
+        coEvery { lambdaRepository.getOrderDetail(any(), any()) } returns orderDetails
+        viewModel.fetchOrderDetail(orderNumber)
         
         coEvery { lambdaRepository.deleteOrder(currentDate, orderNumber) } returns false
 
         // When
-        viewModel.deleteOrder(orderNumber)
+        viewModel.deleteOrder()
 
         // Then
         coVerify { lambdaRepository.deleteOrder(currentDate, orderNumber) }
-        verify { deleteStatusObserver.onChanged(OrdersViewModel.DeleteStatus.Loading) }
-        verify { deleteStatusObserver.onChanged(match { it is OrdersViewModel.DeleteStatus.Error && it.message == "주문 삭제에 실패했습니다." }) }
-        verify { deleteResultObserver.onChanged(false) }
-        
-        viewModel.deleteStatus.removeObserver(deleteStatusObserver)
-        viewModel.deleteResult.removeObserver(deleteResultObserver)
+        val finalState = viewModel.uiState.first()
+        assertTrue(finalState.deleteStatus is OrdersViewModel.DeleteStatus.Error)
+        assertEquals("주문 삭제에 실패했습니다.", (finalState.deleteStatus as OrdersViewModel.DeleteStatus.Error).message)
     }
 
     @Test
     fun `deleteOrder should update deleteStatus to Error when repository throws exception`() = runTest {
         // Given
+        val orderDetails = arrayListOf(OrdersDetailItem("Coffee", 1, 1000))
         val orderNumber = 789
         val errorMessage = "Network connection failed"
         val exception = RuntimeException(errorMessage)
-        val deleteStatusObserver = mockk<Observer<OrdersViewModel.DeleteStatus>>(relaxed = true)
-        val deleteResultObserver = mockk<Observer<Boolean?>>(relaxed = true)
         
-        viewModel.deleteStatus.observeForever(deleteStatusObserver)
-        viewModel.deleteResult.observeForever(deleteResultObserver)
+        // Set up the UI state with order details
+        viewModel.selectOrder(orderNumber, 1000)
+        coEvery { lambdaRepository.getOrderDetail(any(), any()) } returns orderDetails
+        viewModel.fetchOrderDetail(orderNumber)
         
         coEvery { lambdaRepository.deleteOrder(any(), any()) } throws exception
 
         // When
-        viewModel.deleteOrder(orderNumber)
+        viewModel.deleteOrder()
 
         // Then
-        verify { deleteStatusObserver.onChanged(OrdersViewModel.DeleteStatus.Loading) }
-        verify { deleteStatusObserver.onChanged(match { it is OrdersViewModel.DeleteStatus.Error && it.message == "오류가 발생했습니다. 다시 시도해주세요." }) }
-        verify { deleteResultObserver.onChanged(false) }
-        
-        viewModel.deleteStatus.removeObserver(deleteStatusObserver)
-        viewModel.deleteResult.removeObserver(deleteResultObserver)
+        val finalState = viewModel.uiState.first()
+        assertTrue(finalState.deleteStatus is OrdersViewModel.DeleteStatus.Error)
+        assertEquals("오류가 발생했습니다. 다시 시도해주세요.", (finalState.deleteStatus as OrdersViewModel.DeleteStatus.Error).message)
     }
 
     @Test
-    fun `resetDeleteStatus should set deleteStatus to Idle and deleteResult to null`() = runTest {
-        // Given
-        val deleteStatusObserver = mockk<Observer<OrdersViewModel.DeleteStatus>>(relaxed = true)
-        val deleteResultObserver = mockk<Observer<Boolean?>>(relaxed = true)
-        
-        viewModel.deleteStatus.observeForever(deleteStatusObserver)
-        viewModel.deleteResult.observeForever(deleteResultObserver)
-
+    fun `resetDeleteStatus should set deleteStatus to Idle`() = runTest {
         // When
         viewModel.resetDeleteStatus()
 
         // Then
-        verify { deleteStatusObserver.onChanged(OrdersViewModel.DeleteStatus.Idle) }
-        verify { deleteResultObserver.onChanged(null) }
-        
-        viewModel.deleteStatus.removeObserver(deleteStatusObserver)
-        viewModel.deleteResult.removeObserver(deleteResultObserver)
+        val uiState = viewModel.uiState.first()
+        assertTrue(uiState.deleteStatus is OrdersViewModel.DeleteStatus.Idle)
     }
 }

--- a/app/src/test/kotlin/eloom/holybean/ui/orderlist/OrdersViewModelTest.kt
+++ b/app/src/test/kotlin/eloom/holybean/ui/orderlist/OrdersViewModelTest.kt
@@ -77,6 +77,26 @@ class OrdersViewModelTest {
     }
 
     @Test
+    fun `fetchOrderDetail should post error message when order list is empty`() = runTest {
+        // Given
+        val orderNumber = 123
+        val emptyOrderDetails = arrayListOf<OrdersDetailItem>()
+        val errorObserver = mockk<Observer<String>>(relaxed = true)
+        viewModel.error.observeForever(errorObserver)
+
+        val currentDate = viewModel.getCurrentDate()
+        coEvery { lambdaRepository.getOrderDetail(currentDate, orderNumber) } returns emptyOrderDetails
+
+        // When
+        viewModel.fetchOrderDetail(orderNumber)
+
+        // Then
+        coVerify { lambdaRepository.getOrderDetail(currentDate, orderNumber) }
+        verify { errorObserver.onChanged("주문 내역이 없습니다.") }
+        viewModel.error.removeObserver(errorObserver)
+    }
+
+    @Test
     fun `fetchOrderDetail should post error message on repository failure`() = runTest {
         // Given
         val orderNumber = 456
@@ -91,7 +111,7 @@ class OrdersViewModelTest {
         viewModel.fetchOrderDetail(orderNumber)
 
         // Then
-        val expectedErrorMessage = "Failed to fetch order details: $errorMessage"
+        val expectedErrorMessage = "주문 조회 중 오류가 발생했습니다: $errorMessage"
         verify { errorObserver.onChanged(expectedErrorMessage) }
         viewModel.error.removeObserver(errorObserver)
     }


### PR DESCRIPTION
## 변경사항
- **OrderFragment MVVM/상태관리 전환**
  - `OrdersFragment`를 View/UI 중심으로 단순화: `repeatOnLifecycle`로 `StateFlow/SharedFlow` 수집, 다이얼로그/토스트 처리 분리.
  - `MainActivityListener`만 의존, `LambdaRepository` 직접 의존 제거.
  - 선택 주문, 상세 조회, 재출력, 삭제 버튼 로직을 `OrdersViewModel`로 위임.
  - 뷰 바인딩 생명주기 안전 처리(`_binding` 패턴).

- **ViewModel 리팩토링**
  - `OrdersUiState`와 `OrdersUiEvent` 도입: 주문 목록, 선택 주문, 상세, 삭제 상태(`Idle/Loading/Success/Error`)를 `StateFlow`로 노출.
  - `SharedFlow`로 토스트/리프레시 이벤트 발행.
  - 주요 메서드: `loadOrdersOfDay()`, `selectOrder()`, `fetchOrderDetail()`, `reprint()`, `deleteOrder()`, `resetDeleteStatus()`.

- **RecyclerView → ListAdapter/DiffUtil 전환**
  - `OrdersAdapter`: `ListAdapter<OrderItem, …>`로 변경, 클릭 콜백 `(orderNumber, totalAmount) -> Unit` 주입 방식으로 decouple. `submitList` 사용.
  - `OrdersDetailAdapter`: `ListAdapter<OrdersDetailItem, …>`로 변경, `submitList` 사용. Diff 로직 추가.
  - 이에 따라 수동 `notifyDataSetChanged`/내부 리스트 보관 제거.

- **CreditsFragment 연동 정리**
  - `OrdersDetailAdapter`를 필드로 보관하고 `submitList(emptyList())` 등으로 갱신.
  - 기존 어댑터 재생성/전체 갱신 제거.

- **DI/코루틴 디스패처 주입**
  - `NetworkModule`에 `CoroutineDispatcher = Dispatchers.Main` 제공 추가.
  - `OrdersViewModel`에서 디스패처를 주입받아 코루틴 실행.

- **테스트 보강**
  - `OrdersViewModelTest`를 `StateFlow/SharedFlow` 기반으로 전면 갱신.
  - 주문 목록 로드, 주문 선택, 상세 조회 성공/실패, 재출력 성공/에러, 삭제 성공/실패/예외, 삭제 상태 리셋까지 커버.

## 추후 적용사항
- **Dispatcher 구성 개선**
  - `@IoDispatcher`/`@MainDispatcher` 등 Qualifier로 구분 주입하고, 데이터 소스 호출은 `Dispatchers.IO`로 분리.
  - `Dispatchers.Main` 직접 주입 대신 디스패처 모듈로 일원화.

- **Printer 의존성 주입**
  - `OrdersPrinter` 직접 생성 제거하고 인터페이스/팩토리 주입으로 테스트 용이성 강화.

- **일관성 리팩토링 확장**
  - 다른 Fragment/Adapter에도 `ListAdapter + DiffUtil`과 `StateFlow` 패턴 확산.
  - `OrdersDetailItem` Diff 기준을 안정 키(예: 항목 ID)로 재검토.