### PR TITLE
ci: GitHub Release 트리거 Firebase App Distribution 배포 체인

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -1,0 +1,52 @@
+---
+name: release
+description: Cut a new HolyBean Android release — bump the app version (MAJOR.MINOR), curate feature-focused Korean release notes from the commits since the last tag, commit, and create a GitHub Release that triggers the Firebase App Distribution workflow. Use when the user wants to release or deploy the app (e.g. "/release", "/release major", "배포해줘", "릴리즈 내자").
+---
+
+# HolyBean 릴리스 스킬
+
+GitHub Release 발행 → `.github/workflows/distribute.yml` 가 자동으로 APK 빌드 후 Firebase App Distribution
+에 업로드한다. 이 스킬은 그 Release 를 만드는 일까지(버전 범프 + 노트 큐레이션 + 커밋 + `gh release create`)를 담당한다.
+
+## 버전 규칙 (MAJOR.MINOR — patch 없음)
+- `versionName = MAJOR.MINOR`. 작은 변경도 전부 **minor** 로 흡수한다.
+  - `major`: 호환 깨지는 변경 / 대규모 아키텍처 개편(예: v3 급). **사용자가 명시할 때만.**
+  - `minor`: 그 외 모든 변경(기능 추가·버그 수정 포함). **기본값.**
+- `versionCode` 는 `android/app/build.gradle.kts` 가 `appVersionName` 에서 자동 파생(`MAJOR*100+MINOR`)하므로
+  직접 건드리지 않는다. 이 스킬은 `appVersionName` **한 줄만** 고친다.
+- 태그/릴리스명은 `vMAJOR.MINOR` (예: `v3.1`, `v4.0`).
+
+## 절차
+
+1. **범프 타입 결정** — 인자로 `major` 가 들어온 경우에만 major, 그 외(인자 없음 포함)는 **무조건 minor**.
+   커밋을 분석해 타입을 바꾸거나 사용자에게 되묻지 않는다.
+
+2. **현재/다음 버전 계산** — `android/app/build.gradle.kts` 에서 `val appVersionName = "X.Y"` 를 읽는다.
+   - minor → `X.(Y+1)`  ·  major → `(X+1).0`
+   - 직전 태그: `git describe --tags --abbrev=0` (예: `v3.0.0`).
+
+3. **버전 갱신** — `appVersionName` 라인의 값만 새 버전으로 Edit. (versionCode 는 gradle 이 파생)
+
+4. **릴리스 노트 큐레이션 (직접 explore)** — 단순 `git log` 덤프 금지.
+   - `git log <직전태그>..HEAD --oneline` 으로 대상 커밋을 모은다.
+   - 변경 규모가 모호하면 `git show <sha>` / `git diff <직전태그>..HEAD --stat` 으로 **실제 변경을 살펴본다.**
+   - 사용자(매장 운영자) 관점에서 **무엇이 좋아졌는가** 중심으로 한글 노트를 작성한다.
+     기능 추가·개선·버그 수정을 묶고, 내부 리팩터링/빌드 잡일은 묶거나 생략한다.
+   - 형식 예:
+     ```
+     ## v3.1
+     - (기능) …
+     - (개선) …
+     - (수정) …
+     ```
+
+5. **커밋 & 푸시** — 버전 범프를 `chore(release): vX.Y` 로 커밋하고 `git push`.
+
+6. **릴리스 생성** — `gh release create vX.Y --title "vX.Y" --notes "<큐레이션된 노트>"`.
+   → `distribute.yml` (`on: release: published`) 가 트리거되어 빌드·업로드를 수행한다.
+
+7. **안내** — `gh run watch` 또는 Actions 실행 URL 을 사용자에게 알려 배포 진행을 추적하게 한다.
+
+## 주의
+- 푸시/릴리스 생성은 되돌리기 어려운 outward-facing 작업이다. 버전과 노트를 사용자에게 한 번 보여주고 진행한다.
+- `appVersionName` 라인 형식(`val appVersionName = "X.Y"`)이 바뀌면 3번 Edit 가 실패하니 형식을 유지할 것.

--- a/.github/workflows/distribute.yml
+++ b/.github/workflows/distribute.yml
@@ -1,0 +1,34 @@
+name: Distribute to Firebase App Distribution
+
+# 본인이 GitHub Release 를 Publish 할 때만 실행 (수동 릴리스 트리거).
+# 릴리스는 보통 로컬 `/release` 스킬이 사용자 gh 인증으로 생성하므로 release 이벤트가 정상 트리거된다.
+on:
+  release:
+    types: [published]
+
+jobs:
+  distribute:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: android
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: '17'
+
+      # 서비스 계정 키(공식 ADC 경로)를 Secret 에서 파일로 복원
+      - name: Restore service account key
+        run: printf '%s' '${{ secrets.FIREBASE_SERVICE_ACCOUNT_JSON }}' > "$RUNNER_TEMP/sa-key.json"
+
+      # GitHub Release 본문을 App Distribution 릴리스 노트로 전달 (gradle: rootProject/release-notes.txt)
+      - name: Write release notes from GitHub Release body
+        run: printf '%s' "${{ github.event.release.body }}" > release-notes.txt
+
+      - name: Build & distribute
+        env:
+          GOOGLE_APPLICATION_CREDENTIALS: ${{ runner.temp }}/sa-key.json
+        run: ./gradlew assembleRelease appDistributionUploadRelease --stacktrace

--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,6 @@ firebase/public/firebase-config.js
 
 # Superpowers brainstorming companion
 .superpowers/
+
+# Firebase App Distribution: 워크플로/스킬이 GitHub Release 본문에서 생성하는 릴리스 노트
+android/release-notes.txt

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -1,3 +1,4 @@
+import com.google.firebase.appdistribution.gradle.firebaseAppDistribution
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import java.util.Properties
 
@@ -11,6 +12,7 @@ plugins {
     id("org.jetbrains.kotlin.plugin.serialization")
     id("com.google.gms.google-services")
     id("com.google.firebase.crashlytics")
+    id("com.google.firebase.appdistribution")
 }
 
 // Feature flags: local.properties → -P gradle property → default.
@@ -31,8 +33,10 @@ android {
     defaultConfig {
         applicationId = "eloom.holybean"
         minSdk = 31
-        versionCode = 2
-        versionName = "2.0"
+        // 버전은 versionName(MAJOR.MINOR) 단일 소스에서 파생한다. 릴리스 스킬은 appVersionName 한 줄만 갱신.
+        val appVersionName = "3.0"
+        versionName = appVersionName
+        versionCode = appVersionName.split(".").let { (maj, min) -> maj.toInt() * 100 + min.toInt() }  // 3.0 → 300
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {
@@ -55,6 +59,14 @@ android {
             // Play 미경유 내부 배포용: debug 키로 서명해 별도 키스토어 없이 설치 가능.
             // (실제 Play 프로덕션 출시 시 전용 release signingConfig로 교체할 것)
             signingConfig = signingConfigs.getByName("debug")
+
+            // Firebase App Distribution: CI(distribute.yml)에서 GOOGLE_APPLICATION_CREDENTIALS(서비스 계정 키)로 인증.
+            // release-notes.txt 는 워크플로가 GitHub Release 본문으로 생성한다.
+            firebaseAppDistribution {
+                artifactType = "APK"
+                testers = "bumshik0126@gmail.com"
+                releaseNotesFile = rootProject.file("release-notes.txt").absolutePath
+            }
         }
     }
     compileOptions {

--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -15,5 +15,6 @@ plugins {
     id("com.google.devtools.ksp") version "2.3.2" apply false
     id("com.google.gms.google-services") version "4.4.2" apply false
     id("com.google.firebase.crashlytics") version "3.0.2" apply false
+    id("com.google.firebase.appdistribution") version "5.2.1" apply false
     id("org.jetbrains.kotlin.plugin.serialization") version "2.2.20" apply false
 }


### PR DESCRIPTION
## 개요
본인이 발행한 **GitHub Release(`published`)를 트리거로** Android 앱을 Firebase App Distribution에 자동 배포하는 CI 체인을 추가한다. 단일 사용자(본인) 운용 기준. release-please 같은 상시 자동화는 워크플로 비대화 우려로 제외하고, 릴리스 컷은 `/release` 스킬로 수행한다.

## 변경 사항
- **`.github/workflows/distribute.yml`** — `release: published` → `assembleRelease` + `appDistributionUploadRelease`. 인증은 공식 경로(서비스 계정 키 → `GOOGLE_APPLICATION_CREDENTIALS`). 액션 최신: `checkout@v6`, `setup-java@v5`.
- **`android/build.gradle.kts` · `android/app/build.gradle.kts`** — App Distribution Gradle 플러그인(`5.2.1`) 적용 + `firebaseAppDistribution{}` 설정. 버전을 `versionName`(MAJOR.MINOR) 단일 소스에서 파생(`versionCode = MAJOR*100+MINOR`). 태그는 `v3.0.0`까지 갔으나 in-app `versionName`이 `"2.0"`에 머물던 드리프트를 **`3.0`으로 정렬**.
- **`.claude/skills/release/SKILL.md`** — `/release` 스킬. 기본 `minor`(명시 시만 `major`), 직전 태그 이후 커밋을 explore해 **기능 중심 한글 릴리스 노트 큐레이션** 후 `gh release create`.
- **`.gitignore`** — 워크플로 생성물 `android/release-notes.txt` 무시.

## 검증
- `./gradlew :app:tasks` → `appDistributionUploadRelease` 등록 + `BUILD SUCCESSFUL` 확인 (플러그인·DSL·버전 파생 유효).

## ⚠️ 머지 후 필요한 수동 단계
- [ ] GCP 서비스 계정 생성 + `roles/firebaseappdistro.admin` + JSON 키 발급
- [ ] GitHub Secret 등록: `gh secret set FIREBASE_SERVICE_ACCOUNT_JSON < sa-key.json`
- [ ] (보류) 태블릿 회수 후 App Tester 설치로 실기기 설치 검증 — App Distribution 활성화·테스터 초대는 완료됨
- [ ] 첫 배포: `/release` → `v3.1` 컷 → Actions 빌드·업로드 확인

> 주의: `distribute.yml`은 **main에 머지된 후**라야 release 이벤트로 실행된다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)